### PR TITLE
Some mysql login fixes

### DIFF
--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -1,12 +1,11 @@
 # {{ ansible_managed }}
 
 [mysqldump]
-user={{ gcoop_mysqldump_mysql_username }}
-password={{ gcoop_mysqldump_mysql_password }}
+user={{ gcoop_mysqldump_mysql_username | quote }}
+password={{ gcoop_mysqldump_mysql_password | quote }}
 default-character-set=utf8
 
 [client]
-user={{ gcoop_mysqldump_mysql_username }}
-password={{ gcoop_mysqldump_mysql_password }}
+user={{ gcoop_mysqldump_mysql_username | quote }}
+password={{ gcoop_mysqldump_mysql_password | quote }}
 default-character-set=utf8
-

--- a/templates/mysqldump.sh.j2
+++ b/templates/mysqldump.sh.j2
@@ -108,7 +108,7 @@ do
 
   START=$($DATE +%s)
   OPT=$(echo "$OPTIONS" | $TR "\n" " ")
-  $DUMP -u $USER $OPT $DB | $GZIP $GZIP_OPT >"$FILE" 2>"$TMP"
+  $DUMP $OPT $DB | $GZIP $GZIP_OPT >"$FILE" 2>"$TMP"
   [[ -s "$TMP" ]] && log_error $($CAT "$TMP" | $TR "\n" " ")
   [[ -e "$TMP" ]] && $RM -f "$TMP"
   END=$($DATE +%s)


### PR DESCRIPTION
Hi,
i just implemented this in our ansible setup and stumbled about those two issues.

1. The `mysqldump.sh` script uses the system user to login into mysql, which doesn't work if it differs from the actual mysql user. By default the system and mysql user have the same name, which was not the case in our setup so we ran into this issue.
  I just removed the `-u` option as the user already gets set in the `.my.cnf` file.
2. The `.my.cnf` didn't quote the password which caused problems if the password had some special chars. The quote filter surrounds the values with single quotes which solves the problem.