### PR TITLE
 Update Main.yml to fix a deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: verify python-mysqldb installed
   apt:
     name: python-mysqldb
-    state: installed
+    state: present
 
 - name: create mysql user
   mysql_user:


### PR DESCRIPTION
[DEPRECATION WARNING]: State 'installed' is deprecated. Using state 'present' 
instead.. This feature will be removed in version 2.9. Deprecation warnings can
 be disabled by setting deprecation_warnings=False in ansible.cfg.